### PR TITLE
Add context as event property

### DIFF
--- a/log4net.unity/log4net/LogMethod.cs
+++ b/log4net.unity/log4net/LogMethod.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Globalization;
+using log4net.Core;
+using log4net.Unity;
+using log4net.Util;
 
 namespace log4net
 {
@@ -243,5 +247,51 @@ namespace log4net
                     break;
             }
         }
+
+        private Level GetLevel()
+        {
+            switch (logType)
+            {
+                case LogExt.LogType.Debug:
+                    return Level.Debug;
+                case LogExt.LogType.Info:
+                    return Level.Info;
+                case LogExt.LogType.Warn:
+                    return Level.Warn;
+                case LogExt.LogType.Error:
+                    return Level.Error;
+                case LogExt.LogType.Fatal:
+                    return Level.Fatal;
+            }
+            return Level.Verbose;
+        }
+
+        public void CallFormat(UnityEngine.Object ctx, string format, params object[] args)
+        {
+            if (!target.IsEnabled(logType)) return;
+            var evt = new LoggingEvent(ThisDeclaringType, target.Logger.Repository, target.Logger.Name, GetLevel(), new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            if (ctx != null)
+                evt.Properties[UnityDefaultLogAppender.UnityContext] = ctx;
+            target.Logger.Log(evt);
+        }
+        public void Call(UnityEngine.Object ctx, string msg)
+        {
+            if (!target.IsEnabled(logType)) return;
+            var evt = new LoggingEvent(ThisDeclaringType, target.Logger.Repository, target.Logger.Name, GetLevel(), msg, null);
+            if(ctx != null)
+                evt.Properties[UnityDefaultLogAppender.UnityContext] = ctx;
+            target.Logger.Log(evt);
+        }
+
+        public void Call(UnityEngine.Object ctx, string msg, Exception e)
+        {
+            if (!target.IsEnabled(logType)) return;
+            var evt = new LoggingEvent(ThisDeclaringType, target.Logger.Repository, target.Logger.Name, GetLevel(), msg, e);
+            if (ctx != null)
+                evt.Properties[UnityDefaultLogAppender.UnityContext] = ctx;
+            target.Logger.Log(evt);
+        }
+
+        private static readonly Type ThisDeclaringType = typeof(LogImpl);
     }
-}
+    }

--- a/log4net.unity/log4net/Unity/UnityDefaultLogAppender.cs
+++ b/log4net.unity/log4net/Unity/UnityDefaultLogAppender.cs
@@ -2,11 +2,14 @@ using System;
 using log4net.Appender;
 using log4net.Core;
 using UnityEngine;
+using Object = System.Object;
 
 namespace log4net.Unity
 {
     public class UnityDefaultLogAppender: AppenderSkeleton
     {
+        public const string UnityContext = "unity:context";
+
         private static readonly int ErrorLevel = Level.Error.Value;
         private static readonly int WarnLevel = Level.Warn.Value;
         
@@ -27,18 +30,20 @@ namespace log4net.Unity
                 UnityDefaultLogHandler.unityLogHandler?.LogException(e, null);
                 return;
             }
-            
+
+            var ctx = loggingEvent.LookupProperty(UnityContext) as UnityEngine.Object;
+
             if (level.Value < WarnLevel)
             {
-                UnityDefaultLogHandler.unityLogHandler?.LogFormat(LogType.Log, null, message);
+                UnityDefaultLogHandler.unityLogHandler?.LogFormat(LogType.Log, ctx, "{0}", message);
             }
             else if (level.Value >= WarnLevel && level.Value < ErrorLevel)
             {
-                UnityDefaultLogHandler.unityLogHandler?.LogFormat(LogType.Warning, null, message);
+                UnityDefaultLogHandler.unityLogHandler?.LogFormat(LogType.Warning, ctx, "{0}", message);
             }
             else if(level.Value >= ErrorLevel)
             {
-                UnityDefaultLogHandler.unityLogHandler?.LogFormat(LogType.Error, null, message);
+                UnityDefaultLogHandler.unityLogHandler?.LogFormat(LogType.Error, ctx, "{0}", message);
             }
         }
     }

--- a/log4net.unity/log4net/Unity/UnityDefaultLogHandler.cs
+++ b/log4net.unity/log4net/Unity/UnityDefaultLogHandler.cs
@@ -89,11 +89,11 @@ namespace log4net.Unity
             }
             if (args?.Length > 0)
             {
-                method?.CallFormat(format, args);    
+                method?.CallFormat(context, format, args);    
             }
             else
             {
-                method?.Call(format);
+                method?.Call(context, format);
             }
         }
 
@@ -114,7 +114,7 @@ namespace log4net.Unity
             if(exception == null) return;
             
 
-            logger.Fatal()?.Call(exception.UnityMessageWithStack());
+            logger.Error()?.Call(context, exception.UnityMessageWithStack(), exception);
         }
 
         private UnityDefaultLogHandler(){ }


### PR DESCRIPTION
Hi, two changes
1) bug in UnityDefaultLogAppender - the string is passed to String Format, and so if the debug string has "{" it throws an exception
2) pass UnityEngine.Object content in the LoggingEvent, so the Unity logger can pass it back to unity for context highlighting in the editor.